### PR TITLE
Symfony 2.8|3.0 compatible

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,16 +8,16 @@ services:
             - %iakumai.sphinxsearch.searchd.port%
             - %iakumai.sphinxsearch.searchd.socket%
         calls:
-            - [setBridge, [@iakumai.sphinxsearch.doctrine.bridge]]
+            - [setBridge, ["@iakumai.sphinxsearch.doctrine.bridge"]]
 
     # Doctrine Bridge
     iakumai.sphinxsearch.doctrine.bridge:
         class: %iakumai.sphinxsearch.doctrine.bridge.class%
-        arguments: [@service_container, %iakumai.sphinxsearch.doctrine.entity_manager%, %iakumai.sphinxsearch.indexes%]
+        arguments: ["@service_container", %iakumai.sphinxsearch.doctrine.entity_manager%, %iakumai.sphinxsearch.indexes%]
 
     # Twig extension
     iakumai.sphinxsearch.twig.extension_0:
         class: IAkumaI\SphinxsearchBundle\Twig\SphinxsearchExtension
-        arguments: [@iakumai.sphinxsearch.search]
+        arguments: ["@iakumai.sphinxsearch.search"]
         tags:
             - {name: twig.extension}

--- a/Sphinx/SphinxAPI.php
+++ b/Sphinx/SphinxAPI.php
@@ -427,7 +427,7 @@ class SphinxClient
     /////////////////////////////////////////////////////////////////////////////
 
     /// create a new client object and fill defaults
-    function SphinxClient ()
+    function __construct ()
     {
         // per-client-object settings
         $this->_host        = "localhost";

--- a/Twig/SphinxsearchExtension.php
+++ b/Twig/SphinxsearchExtension.php
@@ -51,7 +51,7 @@ class SphinxsearchExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'sphinx_highlight' => new \Twig_Filter_Function(array($this, 'sphinx_highlight'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('sphinx_highlight', array($this, 'sphinx_highlight'), array('is_safe' => array('html')))
         );
     }
 


### PR DESCRIPTION
Not quoting a scalar starting with "@" is deprecated since Symfony 2.8
Using an instance of "Twig_Filter_Function" for filter
"sphinx_highlight" is deprecated.